### PR TITLE
openapidoc: Fix mongo options validation that product error on openapi doc

### DIFF
--- a/src/conf/models/implementations/mongo-implementation.models.ts
+++ b/src/conf/models/implementations/mongo-implementation.models.ts
@@ -144,7 +144,7 @@ class MongoSocketOptionsImplementation implements SocketOptions {
 	connectTimeoutMS?: number;
 
 	@IsOptional()
-	@IsIn([4, 6, null])
+	@IsIn([4, 6])
 	family?: 4 | 6 | null;
 
 	@IsOptional()
@@ -276,7 +276,7 @@ export class MongoClientOptionsImplementation implements MongoClientOptions {
 	ecdhCurve?: string;
 
 	@IsOptional()
-	@IsIn([4, 6, null])
+	@IsIn([4, 6])
 	family?: 4 | 6 | null;
 
 	@IsOptional()


### PR DESCRIPTION
generate failure durring openapi docummentaion generation if mongo options model is exposed in openapi documentation.